### PR TITLE
`uniformBucketLevelAccess` enabled support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Parameter Name | Type | Sample Value | Default Value | Notes
 `keyFilename`|`string`|`"./key.json"`| |Takes precedence over GCS_KEYFILE
 `maxRetries`|`number`|`5`|`3`| | 
 `projectId`|`string`|`"test-prj-1234"`| |Takes precedence over GCLOUD_PROJECT
-
+`uniformBucketLevelAccess`|`boolean`|`true`| |Signifies whether `uniformBucketLevelAccess` is enabled on the target bucket. When `true`, the `predefinedAcl` parameter is removed from requests [as it causes `400 Bad Request` responses](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request). 
 #### Custom file naming function
 If you need to customize the naming of files then you are able to provide a function that will be called before uploading the file.  The third argument of the function must be a standard node callback so pass any error in the first argument (or null on sucess) and the string name of the file on success.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ export default class MulterGoogleCloudStorage implements multer.StorageEngine {
 
 	private gcsBucket: Bucket;
 	private gcsStorage: Storage;
-	private options: StorageOptions & { acl?: PredefinedAcl, bucket?: string, contentType?: ContentTypeFunction };
+	private options: StorageOptions & { acl?: PredefinedAcl, bucket?: string, contentType?: ContentTypeFunction, uniformBucketLevelAccess?: boolean };
 	private blobFile: {destination?: string, filename: string} = { destination: '', filename: '' };
 		
 	getFilename( req, file, cb ) {
@@ -114,9 +114,11 @@ export default class MulterGoogleCloudStorage implements multer.StorageEngine {
 			var blobName = this.blobFile.destination + this.blobFile.filename;
 			var blob = this.gcsBucket.file(blobName);
 
-			const streamOpts: CreateWriteStreamOptions = {
-				predefinedAcl: this.options.acl || 'private'
-			};
+			const streamOpts: CreateWriteStreamOptions = {};
+
+			if (!this.options.uniformBucketLevelAccess) {
+				streamOpts.predefinedAcl = this.options.acl || 'private'
+			}
 
 			const contentType = this.getContentType(req, file);
 			if (contentType) {
@@ -153,7 +155,7 @@ export default class MulterGoogleCloudStorage implements multer.StorageEngine {
 	};
 }
 
-export function storageEngine(opts?: StorageOptions & { bucket?: string; destination?: any; filename?: any; hideFilename?: boolean; contentType?: ContentTypeFunction }) {
+export function storageEngine(opts?: StorageOptions & { bucket?: string; destination?: any; filename?: any; hideFilename?: boolean; contentType?: ContentTypeFunction, uniformBucketLevelAccess?: boolean }) {
 	return new MulterGoogleCloudStorage(opts);
 }
 


### PR DESCRIPTION
When the target bucket has `uniformBucketLevelAccess` enabled and an insert request contains the parameter `predefinedAcl` the response is `400 Bad Request`. [(doc link)](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request)

This PR provides a configuration option to stop that parameter being sent in the request.  
