### PR TITLE
fix(linkUrl): Swap cloud.google.com to storage.googleapis.com

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -137,7 +137,7 @@ export default class MulterGoogleCloudStorage implements multer.StorageEngine {
 						contentType: blob.metadata.contentType,
 						size: blob.metadata.size,
 						uri: `gs://${blob.metadata.bucket}/${this.blobFile.destination}${filename}`,
-						linkUrl: `https://storage.cloud.google.com/${blob.metadata.bucket}/${this.blobFile.destination}${filename}`,
+						linkUrl: `https://storage.googleapis.com/${blob.metadata.bucket}/${this.blobFile.destination}${filename}`,
 						selfLink: blob.metadata.selfLink,
 						//metadata: blob.metadata
 					})


### PR DESCRIPTION
When I "Copy URL" from the Google Cloud console, it copies a googleapis link. 

This module uses cloud.google.com, visiting a cloud.google.com link redirects me through a bunch of hoops ending up with a GIANT url. As I don't really want that mess in the URL bar... this seems better.

Im not quite sure of the implications of this though, compare these two links by visiting them in the URL bar: 
- https://storage.cloud.google.com/neos-event-calendar-images/LmNvx-CheeseWedge128.png
- https://storage.googleapis.com/neos-event-calendar-images/LmNvx-CheeseWedge128.png