### PR TITLE
Fix/ invoke callback on file removed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,6 +174,7 @@ export default class MulterGoogleCloudStorage implements multer.StorageEngine {
 			var blobName = blobFile.destination + blobFile.filename;
 			var blob = this.gcsBucket.file(blobName);
 			blob.delete();
+			cb();
 		}
 	};
 }


### PR DESCRIPTION
### Issue

Whenever a file is removed because of FIle size limit exceeds, it is stuck forever. 

### How to test?

- Try uploading a large file which will throw File size exceeded. 

### Observation  

The request never ends. 
Because after removing the file it's not calling the callback function. 
As per the code in `multer`, it's expected to the callback function on removed. 

https://github.com/expressjs/multer/blob/4f4326a6687635411a69d70f954f48abb4bce58a/lib/remove-uploaded-files.js#L10-L21
