### PR TITLE
Remove unnecessary constraint where creds or keyfile is required for …

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -37,11 +37,6 @@ describe('MulterGoogleCloudStorage checks', () => {
     expect(() => { cloudStorage(noProj) }).toThrow();
   })
 
-  test('Constructor shall throw error when missing credentials', () => {
-    const noKey = { bucket: 'test', projectId: 'test' };
-    expect(() => { cloudStorage(noKey) }).toThrow();
-  })
-
   test('Constructor shall not throw error when using credentials object', () => {
     const credentials = { bucket: 'test', projectId: 'test', credentials:{} };
     expect(() => { cloudStorage(credentials) }).not.toThrow()

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,9 +115,10 @@ export default class MulterGoogleCloudStorage implements multer.StorageEngine {
 			throw new Error('You have to specify project id for Google Cloud Storage to work.');
 		}
 
-		if (!opts.keyFilename && !opts.credentials) {
-			throw new Error('You have to specify credentials key file or credentials object, for Google Cloud Storage to work.');
-		}
+		/*
+		* If credentials and keyfile are not defined, Google Storage should appropriately be able to locate the
+		* default credentials for the environment see: https://cloud.google.com/docs/authentication/application-default-credentials#search_order
+		*/
 
 		this.gcsStorage = new Storage({
 			projectId: opts.projectId,


### PR DESCRIPTION
When taking a look at https://cloud.google.com/docs/authentication/application-default-credentials#search_order we see how Google Cloud libraries derive credentials in order. Any time we do not pass credentials explicitly when instantiating the Storage class, Google follows the application default credential resolution hierarchy described above.

Requiring users of the lib to pass credentials or key file is an extraneous step when running the code in an environment such as cloud run where the application credentials are automatically derived based on the service account the cloud run is running under.