### PR TITLE
feat: allow arbitrary StorageOptions to be passed into Storage client

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,7 @@ export default class MulterGoogleCloudStorage implements multer.StorageEngine {
 						contentType: blob.metadata.contentType,
 						size: blob.metadata.size,
 						uri: `gs://${blob.metadata.bucket}/${blobFile.destination}${filename}`,
-						linkUrl: `https://storage.googleapis.com/${blob.metadata.bucket}/${blobFile.destination}${filename}`,
+						linkUrl: `${this.gcsStorage.apiEndpoint}/${blob.metadata.bucket}/${blobFile.destination}${filename}`,
 						selfLink: blob.metadata.selfLink,
 						//metadata: blob.metadata
 					})

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,15 +103,15 @@ export default class MulterGoogleCloudStorage implements multer.StorageEngine {
 				:	this.getContentType = opts.contentType || this.getContentType;
 		}
 
-		opts.bucket = opts.bucket || process.env.GCS_BUCKET || null;
-		opts.projectId = opts.projectId || process.env.GCLOUD_PROJECT || null;
-		opts.keyFilename = opts.keyFilename || process.env.GCS_KEYFILE || null;
+		const bucket = opts.bucket || process.env.GCS_BUCKET || null;
+		const projectId = opts.projectId || process.env.GCLOUD_PROJECT || null;
+		const keyFilename = opts.keyFilename || process.env.GCS_KEYFILE || null;
 
-		if (!opts.bucket) {
+		if (!bucket) {
 			throw new Error('You have to specify bucket for Google Cloud Storage to work.');
 		}
 
-		if (!opts.projectId) {
+		if (!projectId) {
 			throw new Error('You have to specify project id for Google Cloud Storage to work.');
 		}
 
@@ -121,12 +121,12 @@ export default class MulterGoogleCloudStorage implements multer.StorageEngine {
 		*/
 
 		this.gcsStorage = new Storage({
-			projectId: opts.projectId,
-			keyFilename: opts.keyFilename,
-			credentials: opts.credentials
+			...opts,
+			projectId,
+			keyFilename,
 		});
 
-		this.gcsBucket = this.gcsStorage.bucket(opts.bucket);
+		this.gcsBucket = this.gcsStorage.bucket(bucket);
 
 		this.options = opts;
 	}


### PR DESCRIPTION
It would be really helpful to be able to pass arbitrary options into the `Storage` constructor, for example to allow the use of a GCS mock such as https://github.com/fsouza/fake-gcs-server in development.

I tried to write a unit test to demonstrate its use, but since the fields were private I wasn't successful, and writing an integration test would have been pretty involved, I think.